### PR TITLE
Added Raw Sentence for On Duplicate Key Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ User::insertOnDuplicateKey(
             'b'  => 2,
         ],
     ],
-    [DB::raw('c=c+1'),'name']
+    [DB::raw('c=c+1'),'a']
 );
-// The name will be updated but not the email.
+// The a field will be updated but not the b field. C will be updated to its current value + 1.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,29 @@ User::insertOnDuplicateKey(
 // The name will be updated but not the email.
 ```
 
+Based on `panyanyany` modification (thanks dude), if you want to update certain columns with different values to the inserted one, you can pass the update as Raw query.    
+
+For example, for this SQL query (where c is a "counter" with 0 value as default)
+```php
+INSERT INTO t1 (a,b) VALUES (1,2)
+  ON DUPLICATE KEY UPDATE c=c+1,a=VALUES(a);
+```
+you can pass the update as the 2nd argument  
+
+```php
+User::insertOnDuplicateKey(
+    [
+        [
+            'a'  => 1,
+            'b'  => 2,
+        ],
+    ],
+    [DB::raw('c=c+1'),'name']
+);
+// The name will be updated but not the email.
+```
+
+
 ### Pivot tables
 
 Call `attachOnDuplicateKey` and `attachIgnore` from a `BelongsToMany` relation to run the inserts in its pivot table. You can pass the data in all of the formats accepted by `attach`.

--- a/src/InsertOnDuplicateKeyServiceProvider.php
+++ b/src/InsertOnDuplicateKeyServiceProvider.php
@@ -8,6 +8,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Query\Builder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Query\Expression;
+
 
 class InsertOnDuplicateKeyServiceProvider extends ServiceProvider
 {
@@ -93,15 +95,20 @@ class InsertOnDuplicateKeyServiceProvider extends ServiceProvider
 
             $sql .= ' on duplicate key update ';
 
+            
+
             // We will update all the columns specified in $values by default.
             if ($columnsToUpdate === null) {
                 $columnsToUpdate = $columns;
             }
 
             foreach ($columnsToUpdate as $column) {
-                $column = $this->grammar->wrap($column);
-
-                $sql .= "$column = VALUES($column),";
+                if (is_a($column, Expression::class)) {
+                    $sql .= $column->getValue().",";
+                } else {
+                    $column = $this->grammar->wrap($column);
+                    $sql .= "$column = VALUES($column),";
+                }
             }
 
             return $this->connection->insert(rtrim($sql, ','), $bindings);

--- a/tests/InsertOnDuplicateKeyTest.php
+++ b/tests/InsertOnDuplicateKeyTest.php
@@ -2,6 +2,7 @@
 
 namespace InsertOnDuplicateKey;
 
+use DB;
 use Carbon\Carbon;
 use InsertOnDuplicateKey\Models\Role;
 use InsertOnDuplicateKey\Models\User;
@@ -120,4 +121,40 @@ class InsertOnDuplicateKeyTest extends InsertOnDuplicateKeyTestCase
             'expires_at' => Carbon::tomorrow(),
         ]);
     }
+/**
+ * This test will update ONLY the counter value to +1
+ *
+ * @return void
+ */
+    public function testCounterUpdate() {
+        //Current value of id:3 name:foo email:foo@gmail.com
+
+        $newUser = [
+            'id'    => 3,
+            'name'  => 'new name c',
+            'email' => 'counter@gmail.com',
+        ];
+        User::insertOnDuplicateKey([$newUser],[DB::raw('counter=counter+1')]);
+        $this->assertDatabaseHas('users',["id"=>3,"name"=>"foo","email"=>"foo@gmail.com","counter"=>1,"counter_updated_at"=>null]);
+      
+    }
+
+    /**
+ * This test will update all data and  the counter value to +1 and the counter_updated_at
+ *
+ * @return void
+ */
+public function testCounterAndDataUpdate() {
+    //Current value of id:3 name:foo email:foo@gmail.com
+
+    $newUser = [
+        'id'    => 3,
+        'name'  => 'new name c',
+        'email' => 'counter@gmail.com',
+    ];
+    $date = Carbon::tomorrow();
+    User::insertOnDuplicateKey([$newUser],['name','email',DB::raw('counter=counter+1'),DB::raw("counter_updated_at='".$date."'")]);
+    $this->assertDatabaseHas('users',["id"=>3,"name"=>"new name c","email"=>"counter@gmail.com","counter"=>1,"counter_updated_at"=>$date]);
+  
+}
 }

--- a/tests/InsertOnDuplicateKeyTestCase.php
+++ b/tests/InsertOnDuplicateKeyTestCase.php
@@ -31,6 +31,8 @@ abstract class InsertOnDuplicateKeyTestCase extends TestCase
         parent::setUp();
 
         $this->app['config']->set('database.connections.mysql.username', 'root');
+        $this->app['config']->set('database.connections.mysql.password', 'osborne4');
+
         $this->app['config']->set('database.connections.mysql.database', 'eloquent_insert_on_duplicate_key');
 
         $this->migrate('up');

--- a/tests/InsertOnDuplicateKeyTestCase.php
+++ b/tests/InsertOnDuplicateKeyTestCase.php
@@ -31,7 +31,7 @@ abstract class InsertOnDuplicateKeyTestCase extends TestCase
         parent::setUp();
 
         $this->app['config']->set('database.connections.mysql.username', 'root');
-        $this->app['config']->set('database.connections.mysql.password', 'osborne4');
+        $this->app['config']->set('database.connections.mysql.password', 'xxxx');
 
         $this->app['config']->set('database.connections.mysql.database', 'eloquent_insert_on_duplicate_key');
 

--- a/tests/Migrations/2014_10_12_000000_create_users_table.php
+++ b/tests/Migrations/2014_10_12_000000_create_users_table.php
@@ -17,6 +17,9 @@ class CreateUsersTable extends Migration
             $table->increments('id');
             $table->string('name');
             $table->string('email')->nullable();
+            $table->integer('counter')->default(0);
+            $table->timestamp('counter_updated_at')->nullable();
+            
         });
     }
 


### PR DESCRIPTION
Hi,

thanks for your very usefull package. While I was using it, i noticed that a SQL sentence such as 

> INSERT INTO t1 (a,b,c) VALUES (1,2,3)
  ON DUPLICATE KEY UPDATE c=c+1;

> 

cannot be created using your current package. I saw the **panyanyany** solution and was exactly what I needed, but it was not finished.

So Based on his solution, I've updated the package. For managing that c=c+1.  Such code must be included as Raw in the 2nd array. If it is not included as Raw it will (as your solution) included as a=VALUES(a)

`User::insertOnDuplicateKey([$newUser],['name',DB::raw('counter=counter+1')]);`

Previous sentence will update the field **name** with the new data, **counter** field to its current value + 1

I've included 2 new tests to your tests. For performing the test I've modified the Users Migration adding 2 new fields: counter (integer, default 0) and counter_updated_at (timestamp nullable)

Test #1 _testCounterUpdate_ : field is inserted, but only the counter is updated (to +1)
Test #2 _testCounterAndDataUpdate_ :  field is inserted and name, email, counter (+1) and counter_updated_at (tomorrow date) are updated

thanks for all. 